### PR TITLE
Add branch build workflow for dev and release artifacts

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,0 +1,86 @@
+name: Branch Builds
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: branch-build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ github.ref_name }} binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_prefix: obsyncgit-linux-x86_64
+            artifact_ext: tar.gz
+          - os: macos-latest
+            artifact_prefix: obsyncgit-macos
+            artifact_ext: tar.gz
+          - os: windows-latest
+            artifact_prefix: obsyncgit-windows-x86_64
+            artifact_ext: zip
+    env:
+      BUILD_TYPE: ${{ github.ref_name == 'main' && 'release' || 'dev' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Package binary (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARTIFACT_NAME="${{ matrix.artifact_prefix }}-${BUILD_TYPE}.${{ matrix.artifact_ext }}"
+          DIST_DIR="dist"
+          mkdir -p "${DIST_DIR}"
+          cp target/release/obsyncgit "${DIST_DIR}/obsyncgit"
+          tar -C "${DIST_DIR}" -czf "${ARTIFACT_NAME}" obsyncgit
+          echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> "$GITHUB_ENV"
+          echo "ARTIFACT_PATH=$(pwd)/${ARTIFACT_NAME}" >> "$GITHUB_ENV"
+
+      - name: Package binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $artifactName = "${{ matrix.artifact_prefix }}-$env:BUILD_TYPE.${{ matrix.artifact_ext }}"
+          $dist = Join-Path $PWD "dist"
+          New-Item -ItemType Directory -Path $dist -Force | Out-Null
+          Copy-Item "target\release\obsyncgit.exe" (Join-Path $dist "obsyncgit.exe") -Force
+          $archivePath = Join-Path $PWD $artifactName
+          Compress-Archive -Path (Join-Path $dist "obsyncgit.exe") -DestinationPath $archivePath -Force
+          Add-Content -Path $env:GITHUB_ENV -Value "ARTIFACT_NAME=$artifactName"
+          Add-Content -Path $env:GITHUB_ENV -Value "ARTIFACT_PATH=$archivePath"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACT_PATH }}
+          if-no-files-found: error
+
+      - name: Summarize build type
+        run: |
+          echo "## Build summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch: ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Build type: ${BUILD_TYPE}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifact: ${{ env.ARTIFACT_NAME }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- OS: ${{ runner.os }}" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Run `obsyncgit update --force` to trigger a one-off update when automatic update
 
 ## Releases & auto-updates
 
+Every push to `develop` and `main` now triggers the **Branch Builds** workflow. It compiles release-mode binaries for Linux, macOS, and Windows, then uploads artifacts named `obsyncgit-<platform>-dev.*` for `develop` and `obsyncgit-<platform>-release.*` for `main`. Grab these from the corresponding workflow run when you need a fresh dev build without waiting for a full release.
+
 Pushing a tag matching `v*` triggers the `release` GitHub Actions workflow. It now builds and packages binaries for:
 - Linux x86_64 (`obsyncgit-linux-x86_64.tar.gz`)
 - Linux ARM64 (`obsyncgit-linux-aarch64.tar.gz`)


### PR DESCRIPTION
## Summary
- add a Branch Builds workflow that builds release binaries for pushes to main and develop
- upload branch-specific artifacts so develop creates dev builds and main creates release builds
- document the new branch build process in the README

## Testing
- cargo test --all --locked

------
https://chatgpt.com/codex/tasks/task_e_68d663584e008333acf537530b50ce53