### PR TITLE
Ensure branch builds include GUI artifacts

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -41,8 +41,17 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Install Linux GUI build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libgtk-3-dev libglib2.0-dev libgobject-2.0-dev libgirepository1.0-dev libayatana-appindicator3-dev libxdo-dev
+
       - name: Build release binary
         run: cargo build --release --locked
+
+      - name: Build GUI helper
+        run: cargo build --release --locked --bin obsyncgit-gui --features gui
 
       - name: Package binary (Unix)
         if: runner.os != 'Windows'
@@ -53,7 +62,10 @@ jobs:
           DIST_DIR="dist"
           mkdir -p "${DIST_DIR}"
           cp target/release/obsyncgit "${DIST_DIR}/obsyncgit"
-          tar -C "${DIST_DIR}" -czf "${ARTIFACT_NAME}" obsyncgit
+          if [ -f "target/release/obsyncgit-gui" ]; then
+            cp target/release/obsyncgit-gui "${DIST_DIR}/obsyncgit-gui"
+          fi
+          tar -C "${DIST_DIR}" -czf "${ARTIFACT_NAME}" .
           echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> "$GITHUB_ENV"
           echo "ARTIFACT_PATH=$(pwd)/${ARTIFACT_NAME}" >> "$GITHUB_ENV"
 
@@ -65,8 +77,12 @@ jobs:
           $dist = Join-Path $PWD "dist"
           New-Item -ItemType Directory -Path $dist -Force | Out-Null
           Copy-Item "target\release\obsyncgit.exe" (Join-Path $dist "obsyncgit.exe") -Force
+          $guiPath = "target\release\obsyncgit-gui.exe"
+          if (Test-Path $guiPath) {
+            Copy-Item $guiPath (Join-Path $dist "obsyncgit-gui.exe") -Force
+          }
           $archivePath = Join-Path $PWD $artifactName
-          Compress-Archive -Path (Join-Path $dist "obsyncgit.exe") -DestinationPath $archivePath -Force
+          Compress-Archive -Path (Join-Path $dist '*') -DestinationPath $archivePath -Force
           Add-Content -Path $env:GITHUB_ENV -Value "ARTIFACT_NAME=$artifactName"
           Add-Content -Path $env:GITHUB_ENV -Value "ARTIFACT_PATH=$archivePath"
 


### PR DESCRIPTION
## Summary
- install the Linux GUI toolchain in branch builds
- compile the obsyncgit-gui binary alongside the daemon
- package both binaries in the uploaded artifacts for all platforms

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d66dcc034c8333b75db6779b028213