### PR TITLE
chore(ci): drop obsolete gobject package

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -45,7 +45,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libgtk-3-dev libglib2.0-dev libgobject-2.0-dev libgirepository1.0-dev libayatana-appindicator3-dev libxdo-dev
+          sudo apt-get install -y pkg-config libgtk-3-dev libglib2.0-dev libgirepository1.0-dev libayatana-appindicator3-dev libxdo-dev
 
       - name: Build release binary
         run: cargo build --release --locked


### PR DESCRIPTION
## Summary
- удалил libgobject-2.0-dev из установки Linux gui зависимостей
- пакет отсутствует в Ubuntu 24.04, поэтому билд падал

## Testing
- CI